### PR TITLE
decodeの条件にobject.operationStatusを追加

### DIFF
--- a/js-http/src/main/http/entity/Response.ts
+++ b/js-http/src/main/http/entity/Response.ts
@@ -24,7 +24,7 @@ class Response<E> {
     const props = {
       operationKey: object.operationKey,
       operationStatus: object.operationStatus,
-      result: decoder?.(object.result) ?? object.result,
+      result: object.operationStatus && decoder ? decoder(object.result) : object.result,
       errors: object.errors,
     } as ResponseProps<E>
     return new Response(props)


### PR DESCRIPTION
ステータスコードが200で、operationStatusがfalseのときにdecodeが失敗するので、条件追加